### PR TITLE
pkg/Makefile: implement View interface with basic testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,33 @@ jobs:
           echo "::group:: file headers"
           ltag -t "script/validate/template" --excludes "vendor contrib" --check -v
           echo "::endgroup::"
+
+  #
+  # Integration
+  #
+  integration:
+    name: integration
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/alibaba/accelerated-container-image
+          fetch-depth: 100
+
+      - name: install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.15.8'
+
+      - name: set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: unit test
+        working-directory: src/github.com/alibaba/accelerated-container-image
+        run: |
+          sudo GO_TESTFLAGS=-v make test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ DESTDIR=/usr/local/bin
 COMMANDS=overlaybd-snapshotter ctr
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
+# go packages
+GO_PACKAGES=$(shell go list ${GO_TAGS} ./... | grep -v /vendor/)
+
 all: binaries
 
 binaries: $(BINARIES) ## build binaries into bin
@@ -20,6 +23,9 @@ bin/%: cmd/% force
 install: ## install binaries from bin
 	@mkdir -p $(DESTDIR)
 	@install $(BINARIES) $(DESTDIR)
+
+test: ## run tests that require root
+	@go test ${GO_TESTFLAGS} ${GO_PACKAGES} -test.root
 
 clean:
 	@rm -rf ./bin

--- a/pkg/snapshot/overlay_test.go
+++ b/pkg/snapshot/overlay_test.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The Accelerated Container Image Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package snapshot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/pkg/testutil"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/containerd/snapshots/testsuite"
+)
+
+func newSnapshotterWithOpts(opts ...Opt) testsuite.SnapshotterFunc {
+	return func(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
+		snapshotter, err := NewSnapshotter(root, opts...)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return snapshotter, func() error { return snapshotter.Close() }, nil
+	}
+}
+
+func TestBasicSnapshotterOnOverlayFS(t *testing.T) {
+	testutil.RequiresRoot(t)
+	testsuite.SnapshotterSuite(t, "overlaybd-on-overlayFS", newSnapshotterWithOpts())
+}


### PR DESCRIPTION
* Add `make test` to run go test.
* .github: init integration with unit test

Signed-off-by: Wei Fu <fuweid89@gmail.com>